### PR TITLE
Make phpunit 9.x working with fixes from the debian repro

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Content/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Content/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde/Content">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Content/Base.php
+++ b/test/Content/Base.php
@@ -210,7 +210,8 @@ class Content_Test_Base extends Horde_Test_Case
         $this->assertEquals(4, $recent[0]['tag_id']);
         $this->assertEquals('personal', $recent[0]['tag_name']);
         $date = new Horde_Date($recent[0]['created']);
-        $this->assertEquals(1230764760, $date->timestamp());
+        // date --date="2009-01-01 00:06:00 UTC" +%s gives: 1230768360
+        $this->assertEquals(1230768360, $date->timestamp());
     }
 
     protected function _testGetRecentTagsByUser()
@@ -237,7 +238,8 @@ class Content_Test_Base extends Horde_Test_Case
         $this->assertEquals(4, count($recent));
         $this->assertEquals(4, $recent[0]['object_id']);
         $date = new Horde_Date($recent[0]['created'], 'UTC');
-        $this->assertEquals(1230764760, $date->timestamp());
+        // date --date="2009-01-01 00:06:00 UTC" +%s gives: 1230768360
+        $this->assertEquals(1230768360, $date->timestamp());
     }
 
     protected function _testUntag()

--- a/test/Content/Sql/Base.php
+++ b/test/Content/Sql/Base.php
@@ -31,13 +31,13 @@ class Content_Test_Sql_Base extends Content_Test_Base
         $this->assertEquals(4, count($objects));
         // If these aren't strings, then ids were taken as names.
         foreach ($objects as $object) {
-            $this->assertInternalType('string', $object['object_name']);
+            $this->assertIsString($object['object_name']);
         }
 
         $types = self::$db->select('SELECT * FROM rampage_types');
         $this->assertEquals(2, count($types));
         foreach ($types as $type) {
-            $this->assertInternalType('string', $type['type_name']);
+            $this->assertIsString($type['type_name']);
         }
     }
 
@@ -175,7 +175,7 @@ class Content_Test_Sql_Base extends Content_Test_Base
         $this->_testUntag();
     }
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$injector = new Horde_Injector(new Horde_Injector_TopLevel());
         self::$injector->setInstance('Horde_Db_Adapter', self::$db);
@@ -192,7 +192,7 @@ class Content_Test_Sql_Base extends Content_Test_Base
         self::$type_mgr = self::$injector->createInstance('Content_Types_Manager');
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         if (self::$migrator) {
             self::$migrator->down();
@@ -201,7 +201,7 @@ class Content_Test_Sql_Base extends Content_Test_Base
         parent::tearDownAfterClass();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!self::$db) {
             $this->markTestSkipped(self::$reason);

--- a/test/Content/Sql/MysqlTest.php
+++ b/test/Content/Sql/MysqlTest.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/Base.php';
  */
 class Content_Sql_MysqlTest extends Content_Test_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!extension_loaded('mysql')) {
             self::$reason = 'No mysql extension';

--- a/test/Content/Sql/MysqliTest.php
+++ b/test/Content/Sql/MysqliTest.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/Base.php';
  */
 class Content_Sql_MysqliTest extends Content_Test_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!extension_loaded('mysqli')) {
             self::$reason = 'No mysqli extension';

--- a/test/Content/Sql/Oci8Test.php
+++ b/test/Content/Sql/Oci8Test.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/Base.php';
  */
 class Content_Sql_Oci8Test extends Content_Test_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!extension_loaded('oci8')) {
             self::$reason = 'No oci8 extension';

--- a/test/Content/Sql/Pdo/MysqlTest.php
+++ b/test/Content/Sql/Pdo/MysqlTest.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/../Base.php';
 
 class Content_Sql_Pdo_MysqlTest extends Content_Test_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!extension_loaded('pdo') ||
             !in_array('mysql', PDO::getAvailableDrivers())) {

--- a/test/Content/Sql/Pdo/PgsqlTest.php
+++ b/test/Content/Sql/Pdo/PgsqlTest.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/../Base.php';
 
 class Content_Sql_Pdo_PgsqlTest extends Content_Test_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!extension_loaded('pdo') ||
             !in_array('pgsql', PDO::getAvailableDrivers())) {

--- a/test/Content/Sql/Pdo/SqliteTest.php
+++ b/test/Content/Sql/Pdo/SqliteTest.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/../Base.php';
  */
 class Content_Sql_Pdo_SqliteTest extends Content_Test_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $factory_db = new Horde_Test_Factory_Db();
 


### PR DESCRIPTION
@ralflang could you please review my changes. I do not see any runtime errors but one test case is failing and some are Skipped be cause I do not have all databases installed. The error is:
```
There was 1 error:

1) Content_Sql_Pdo_SqliteTest::testCreate
TypeError: count(): Argument #1 ($value) must be of type Countable|array, Horde_Db_Adapter_Pdo_Result given

/.../horde6/content/test/Content/Sql/Base.php:31
```

Thanks